### PR TITLE
:sparkles: Data templating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +361,7 @@ dependencies = [
  "serde_json",
  "shell-words",
  "ssh2",
+ "tinytemplate",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ clap = { version = "3.1", features = ["cargo"] }
 ssh2 = "0.9"
 is_executable = "1.0"
 shell-words = "1.1"
+tinytemplate = "1.2"

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ user = "admin"
 Then, run one of the following commands:
 
 ```
-$ tricorder -i /path/to/inventory -- echo "run on all hosts"
-$ tricorder -i /path/to/inventory -H backend -- echo "run on specific host"
-$ tricorder -i /path/to/inventory -t server,myapp -- echo "run on all hosts matching tags"
+$ tricorder -i /path/to/inventory do -- echo "run on all hosts"
+$ tricorder -i /path/to/inventory -H backend do -- echo "run on specific host"
+$ tricorder -i /path/to/inventory -t server,myapp do -- echo "run on all hosts matching tags"
 ```
 
 > **NB:** Authentication is done via `ssh-agent` only.

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -2,14 +2,22 @@ use crate::{Result, Host};
 
 use clap::ArgMatches;
 use serde_json::{json, Value};
+use tinytemplate::{TinyTemplate, format_unescaped};
 
 pub fn run(hosts: Vec<Host>, matches: &ArgMatches) -> Result<()> {
-  let cmd = get_command(matches.values_of("cmd"));
+  let cmd_tmpl = get_command(matches.values_of("cmd"));
 
   let results: Vec<Value> = hosts
     .iter()
     .map(|host| {
+      let cmd = render_command(host, cmd_tmpl.clone())?;
+      Ok((host, cmd))
+    })
+    .collect::<Result<Vec<(&Host, String)>>>()?
+    .into_iter()
+    .map(|(host, cmd)| {
       eprintln!("Executing command on {}...", host.id);
+
       host.exec(&cmd)
         .map_or_else(
           |err| {
@@ -44,4 +52,14 @@ fn get_command(arg: Option<clap::Values<'_>>) -> String {
     .map(|vals| vals.collect::<Vec<_>>())
     .map(|argv| shell_words::join(argv))
     .unwrap()
+}
+
+fn render_command(host: &Host, cmd_tmpl: String) -> Result<String> {
+  let mut tt = TinyTemplate::new();
+  tt.set_default_formatter(&format_unescaped);
+  tt.add_template("cmd", cmd_tmpl.as_str())?;
+
+  let ctx = json!({ "host": host });
+  let cmd = tt.render("cmd", &ctx)?;
+  Ok(cmd)
 }

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1,0 +1,47 @@
+use crate::{Result, Host};
+
+use clap::ArgMatches;
+use serde_json::{json, Value};
+
+pub fn run(hosts: Vec<Host>, matches: &ArgMatches) -> Result<()> {
+  let cmd = get_command(matches.values_of("cmd"));
+
+  let results: Vec<Value> = hosts
+    .iter()
+    .map(|host| {
+      eprintln!("Executing command on {}...", host.id);
+      host.exec(&cmd)
+        .map_or_else(
+          |err| {
+            json!({
+              "host": host.id,
+              "success": false,
+              "error": format!("{}", err),
+            })
+          },
+          |(exit_code, output)| {
+            json!({
+              "host": host.id,
+              "success": true,
+              "info": {
+                "exit_code": exit_code,
+                "output": output,
+              },
+            })
+          }
+        )
+    })
+    .collect();
+
+  let out = json!(results);
+  println!("{}", out);
+
+  Ok(())
+}
+
+fn get_command(arg: Option<clap::Values<'_>>) -> String {
+  arg
+    .map(|vals| vals.collect::<Vec<_>>())
+    .map(|argv| shell_words::join(argv))
+    .unwrap()
+}

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -1,0 +1,11 @@
+use crate::{Result, Host};
+
+use clap::ArgMatches;
+use serde_json::json;
+
+pub fn run(hosts: Vec<Host>, _matches: &ArgMatches) -> Result<()> {
+  let res = json!({"hosts": hosts});
+  println!("{}", res);
+
+  Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,8 @@
+mod exec;
+
 use crate::{Result, Inventory, Host};
 
-use clap::{command, arg};
+use clap::ArgMatches;
 use is_executable::IsExecutable;
 use std::{
   path::Path,
@@ -8,28 +10,7 @@ use std::{
   fs
 };
 
-pub fn parse_args() -> Result<(Vec<Host>, String)> {
-  let matches = command!()
-    .arg(
-      arg!(inventory: -i --inventory <FILE> "Path to TOML inventory file or program producing JSON inventory")
-      .required(false)
-    )
-    .arg(
-      arg!(host_id: -H --host_id <STR> "Identifier of the host to connect to")
-      .required(false)
-    )
-    .arg(
-      arg!(host_tags: -t --host_tags <STR> "Comma-separated list of tags identifying the hosts to connect to")
-      .required(false)
-    )
-    .arg(
-      arg!(cmd: [COMMAND] "Command to run on each host")
-      .last(true)
-      .required(true)
-    )
-    .get_matches();
-
-  let cmd = get_command(matches.values_of("cmd"));
+pub fn run(matches: ArgMatches) -> Result<()> {
   let inventory = get_inventory(matches.value_of("inventory"))?;
   let hosts = get_host_list(
     inventory,
@@ -37,14 +18,14 @@ pub fn parse_args() -> Result<(Vec<Host>, String)> {
     matches.value_of("host_tags"),
   );
 
-  return Ok((hosts, cmd));
-}
-
-fn get_command(arg: Option<clap::Values<'_>>) -> String {
-  arg
-    .map(|vals| vals.collect::<Vec<_>>())
-    .map(|argv| shell_words::join(argv))
-    .unwrap()
+  match matches.subcommand() {
+    Some(("do", sub_matches)) => {
+      exec::run(hosts, sub_matches)
+    },
+    _ => {
+      unreachable!("Exhausted list of subcommands and subcommand_required prevents `None`")
+    }
+  }
 }
 
 fn get_inventory(arg: Option<&str>) -> Result<Inventory> {
@@ -108,5 +89,5 @@ fn get_host_list(
     return inventory.get_hosts_by_tags(tags);
   }
 
-  return inventory.hosts;
+  return inventory.hosts.clone();
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+mod info;
 mod exec;
 
 use crate::{Result, Inventory, Host};
@@ -21,6 +22,9 @@ pub fn run(matches: ArgMatches) -> Result<()> {
   match matches.subcommand() {
     Some(("do", sub_matches)) => {
       exec::run(hosts, sub_matches)
+    },
+    Some(("info", sub_matches)) => {
+      info::run(hosts, sub_matches)
     },
     _ => {
       unreachable!("Exhausted list of subcommands and subcommand_required prevents `None`")

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,15 +1,17 @@
 use crate::Result;
 
-use serde_derive::Deserialize;
+use serde_json::Value;
+use serde_derive::{Serialize, Deserialize};
 use ssh2::Session;
 
 use std::{
+  collections::HashMap,
   io::prelude::*,
   net::TcpStream,
 };
 
 
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Host {
   pub id: String,
   pub address: String,
@@ -17,6 +19,8 @@ pub struct Host {
   pub user: String,
   #[serde(default = "Host::default_tags")]
   pub tags: Vec<String>,
+  #[serde(default = "Host::default_vars")]
+  pub vars: HashMap<String, Value>,
 }
 
 impl Host {
@@ -45,5 +49,9 @@ impl Host {
 
   pub fn default_tags() -> Vec<String> {
     vec![]
+  }
+
+  pub fn default_vars() -> HashMap<String, Value> {
+    HashMap::new()
   }
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -13,9 +13,9 @@ use std::{
 pub struct Host {
   pub id: String,
   pub address: String,
-  #[serde(default = "default_user")]
+  #[serde(default = "Host::default_user")]
   pub user: String,
-  #[serde(default = "default_tags")]
+  #[serde(default = "Host::default_tags")]
   pub tags: Vec<String>,
 }
 
@@ -38,12 +38,12 @@ impl Host {
 
     Ok((exit_code, output))
   }
-}
 
-fn default_user() -> String {
-  String::from("root")
-}
+  pub fn default_user() -> String {
+    String::from("root")
+  }
 
-fn default_tags() -> Vec<String> {
-  vec![]
+  pub fn default_tags() -> Vec<String> {
+    vec![]
+  }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -2,16 +2,15 @@ use crate::{Result, Host};
 
 use serde_derive::Deserialize;
 
-
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Inventory {
-  #[serde(default = "default_hostlist")]
+  #[serde(default = "Inventory::default_hostlist")]
   pub hosts: Vec<Host>,
 }
 
 impl Inventory {
   pub fn new() -> Self {
-    Inventory { hosts: default_hostlist() }
+    Inventory { hosts: Self::default_hostlist() }
   }
 
   pub fn from_toml(content: &str) -> Result<Self> {
@@ -44,13 +43,14 @@ impl Inventory {
       .map(|host| host.clone())
       .collect()
   }
-}
 
-fn default_hostlist() -> Vec<Host> {
-  vec![Host {
-    id: String::from("localhost"),
-    address: String::from("localhost:22"),
-    user: String::from("root"),
-    tags: vec![],
-  }]
+  pub fn default_hostlist() -> Vec<Host> {
+    vec![Host {
+      id: String::from("localhost"),
+      address: String::from("localhost:22"),
+      user: Host::default_user(),
+      tags: Host::default_tags(),
+      vars: Host::default_vars(),
+    }]
+  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,3 @@
-extern crate toml;
-extern crate serde_json;
-extern crate serde_derive;
-
-extern crate clap;
-extern crate ssh2;
-extern crate is_executable;
-extern crate shell_words;
-
 pub mod inventory;
 pub mod host;
 pub mod cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,10 @@ fn main() -> Result<()> {
       .required(false)
     )
     .subcommand(
+      Command::new("info")
+        .about("Gather information about hosts in the inventory")
+    )
+    .subcommand(
       Command::new("do")
         .about("Execute a command on multiple hosts")
         .arg(


### PR DESCRIPTION
**This PR provides the following changes:**

 - [x] :recycle: Refactor source code for multiple subcommands
 - [x] :sparkles: Add `do` subcommand for previous behavior
 - [x] :sparkles: Add `info` subcommand to dump host info (currently only info from inventory, later info gathered on the host)
 - [x] :heavy_plus_sign: Add [tinytemplate](https://crates.io/crates/tinytemplate) crate
 - [x] :sparkles: Add `vars` field to hosts in inventory
 - [x] :sparkles: Add support for data templating (see #8 )