### PR TITLE
:sparkles: Add external commands

### DIFF
--- a/src/cli/external.rs
+++ b/src/cli/external.rs
@@ -1,0 +1,36 @@
+use crate::Result;
+
+use clap::ArgMatches;
+use std::process::{Command, exit};
+
+
+pub fn run(
+  command: &str,
+  inventory_arg: Option<&str>,
+  host_id_arg: Option<&str>,
+  host_tags_arg: Option<&str>,
+  matches: &ArgMatches,
+) -> Result<()> {
+  let bin = format!("tricorder-{}", command);
+  let args = matches
+    .values_of_os("")
+    .unwrap_or_default()
+    .collect::<Vec<_>>();
+
+  let status = Command::new(bin)
+    .args(args)
+    .env("TRICORDER_INVENTORY", inventory_arg.unwrap_or(""))
+    .env("TRICORDER_HOST_ID", host_id_arg.unwrap_or(""))
+    .env("TRICORDER_HOST_TAGS", host_tags_arg.unwrap_or(""))
+    .status()?;
+
+  match status.code() {
+    Some(code) => {
+      exit(code);
+    },
+    None => {
+      eprintln!("Subcommand was terminated by a signal.");
+      exit(127);
+    }
+  }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+mod external;
 mod info;
 mod exec;
 
@@ -12,19 +13,23 @@ use std::{
 };
 
 pub fn run(matches: ArgMatches) -> Result<()> {
-  let inventory = get_inventory(matches.value_of("inventory"))?;
-  let hosts = get_host_list(
-    inventory,
-    matches.value_of("host_id"),
-    matches.value_of("host_tags"),
-  );
+  let inventory_arg = matches.value_of("inventory");
+  let host_id_arg = matches.value_of("host_id");
+  let host_tags_arg = matches.value_of("host_tags");
 
   match matches.subcommand() {
     Some(("do", sub_matches)) => {
+      let inventory = get_inventory(inventory_arg)?;
+      let hosts = get_host_list(inventory, host_id_arg, host_tags_arg);
       exec::run(hosts, sub_matches)
     },
     Some(("info", sub_matches)) => {
+      let inventory = get_inventory(inventory_arg)?;
+      let hosts = get_host_list(inventory, host_id_arg, host_tags_arg);
       info::run(hosts, sub_matches)
+    },
+    Some((cmd, sub_matches)) => {
+      external::run(cmd, inventory_arg, host_id_arg, host_tags_arg, sub_matches)
     },
     _ => {
       unreachable!("Exhausted list of subcommands and subcommand_required prevents `None`")

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ fn main() -> Result<()> {
   let matches = command!()
     .propagate_version(true)
     .subcommand_required(true)
+    .allow_external_subcommands(true)
+    .allow_invalid_utf8_for_external_subcommands(true)
     .arg(
       arg!(inventory: -i --inventory <FILE> "Path to TOML inventory file or program producing JSON inventory")
       .required(false)


### PR DESCRIPTION
**This PR provides the following changes:**

 - [x] :sparkles: Add support for external subcommand named `tricorder-SUBCOMMAND`
