### PR TITLE
:sparkles: Add upload subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-mode"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773ea145485772b8d354624b32adbe20e776353d3e48c7b03ef44e3455e9815c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +364,7 @@ name = "tricorder"
 version = "0.3.0"
 dependencies = [
  "clap",
+ "file-mode",
  "is_executable",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ clap = { version = "3.1", features = ["cargo"] }
 ssh2 = "0.9"
 is_executable = "1.0"
 shell-words = "1.1"
+file-mode = "0.1"
 tinytemplate = "1.2"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 mod external;
 mod info;
 mod exec;
+mod upload;
 
 use crate::{Result, Inventory, Host};
 
@@ -18,15 +19,20 @@ pub fn run(matches: ArgMatches) -> Result<()> {
   let host_tags_arg = matches.value_of("host_tags");
 
   match matches.subcommand() {
+    Some(("info", sub_matches)) => {
+      let inventory = get_inventory(inventory_arg)?;
+      let hosts = get_host_list(inventory, host_id_arg, host_tags_arg);
+      info::run(hosts, sub_matches)
+    },
     Some(("do", sub_matches)) => {
       let inventory = get_inventory(inventory_arg)?;
       let hosts = get_host_list(inventory, host_id_arg, host_tags_arg);
       exec::run(hosts, sub_matches)
     },
-    Some(("info", sub_matches)) => {
+    Some(("upload", sub_matches)) => {
       let inventory = get_inventory(inventory_arg)?;
       let hosts = get_host_list(inventory, host_id_arg, host_tags_arg);
-      info::run(hosts, sub_matches)
+      upload::run(hosts, sub_matches)
     },
     Some((cmd, sub_matches)) => {
       external::run(cmd, inventory_arg, host_id_arg, host_tags_arg, sub_matches)

--- a/src/cli/upload.rs
+++ b/src/cli/upload.rs
@@ -1,0 +1,165 @@
+use crate::{Result, Host};
+
+use clap::ArgMatches;
+use file_mode::Mode;
+use tinytemplate::{TinyTemplate, format_unescaped};
+use serde_json::{json, Value};
+
+use std::{
+  convert::TryFrom,
+  io::{Error, ErrorKind},
+  path::Path,
+  fs,
+};
+
+pub fn run(hosts: Vec<Host>, matches: &ArgMatches) -> Result<()> {
+  let local_path = get_local_path(matches.value_of("local_path"))?;
+  let remote_path = get_remote_path(matches.value_of("remote_path"))?;
+  let file_mode = get_file_mode(matches.value_of("file_mode"))?;
+
+  if matches.is_present("template") {
+    render_template(hosts, local_path, remote_path, file_mode)
+  }
+  else {
+    send_file(hosts, local_path, remote_path, file_mode)
+  }
+}
+
+fn render_template(
+  hosts: Vec<Host>,
+  local_path: String,
+  remote_path: String,
+  file_mode: i32
+) -> Result<()> {
+  let template = fs::read_to_string(local_path)?;
+
+  let mut tt = TinyTemplate::new();
+  tt.set_default_formatter(&format_unescaped);
+  tt.add_template("file", template.as_str())?;
+
+  let results: Vec<Value> = hosts
+    .iter()
+    .map(|host| {
+      let ctx = json!({"host": host});
+      let content = tt.render("file", &ctx)?;
+      let size = u64::try_from(content.len())?;
+      Ok((host, content, size))
+    })
+    .collect::<Result<Vec<(&Host, String, u64)>>>()?
+    .into_iter()
+    .map(|(host, content, file_size)| {
+      host.send_data(remote_path.clone(), file_mode, file_size, content)
+        .map_or_else(
+          |err| {
+            json!({
+              "host": host.id,
+              "success": false,
+              "error":format!("{}", err),
+            })
+          },
+          |()| {
+            json!({
+              "host": host.id,
+              "success": true,
+            })
+          }
+        )
+    })
+    .collect();
+
+  let out = json!(results);
+  println!("{}", out);
+
+  Ok(())
+}
+
+fn send_file(
+  hosts: Vec<Host>,
+  local_path: String,
+  remote_path: String,
+  file_mode: i32
+) -> Result<()> {
+  let results: Vec<Value> = hosts
+    .iter()
+    .map(|host| {
+      let file_size = fs::metadata(&local_path)?.len();
+      Ok((host, file_size))
+    })
+    .collect::<Result<Vec<(&Host, u64)>>>()?
+    .into_iter()
+    .map(|(host, file_size)| {
+      host.send_file(local_path.clone(), remote_path.clone(), file_mode, file_size)
+        .map_or_else(
+          |err| {
+            json!({
+              "host": host.id,
+              "success": false,
+              "error":format!("{}", err),
+            })
+          },
+          |()| {
+            json!({
+              "host": host.id,
+              "success": true,
+            })
+          }
+        )
+    })
+    .collect();
+
+  let out = json!(results);
+  println!("{}", out);
+
+  Ok(())
+}
+
+fn get_local_path(arg: Option<&str>) -> Result<String> {
+  if let Some(path) = arg {
+    let local_path = Path::new(path);
+
+    if !local_path.exists() {
+      Err(Box::new(Error::new(
+        ErrorKind::NotFound,
+        format!("No such file: {}", path),
+      )))
+    }
+    else if local_path.is_dir() {
+      Err(Box::new(Error::new(
+        ErrorKind::InvalidInput,
+        format!("Path is a directory, not a file: {}", path),
+      )))
+    }
+    else {
+      Ok(String::from(path))
+    }
+  }
+  else {
+    Err(Box::new(Error::new(
+      ErrorKind::Other,
+      "No input file provided",
+    )))
+  }
+}
+
+fn get_remote_path(arg: Option<&str>) -> Result<String> {
+  if let Some(path) = arg {
+    Ok(String::from(path))
+  }
+  else {
+    Err(Box::new(Error::new(
+      ErrorKind::Other,
+      "No input file provided",
+    )))
+  }
+}
+
+fn get_file_mode(arg: Option<&str>) -> Result<i32> {
+  let mut mode = Mode::from(0o644);
+
+  if let Some(mode_str) = arg {
+    mode.set_str(mode_str)?;
+  }
+
+  let file_mode = i32::try_from(mode.mode())?;
+  Ok(file_mode)
+}

--- a/src/host.rs
+++ b/src/host.rs
@@ -6,8 +6,14 @@ use ssh2::Session;
 
 use std::{
   collections::HashMap,
-  io::prelude::*,
+  io::{
+    prelude::*,
+    BufRead,
+    BufReader,
+  },
   net::TcpStream,
+  fs::File,
+  path::Path,
 };
 
 
@@ -25,12 +31,7 @@ pub struct Host {
 
 impl Host {
   pub fn exec(&self, command: &str) -> Result<(i32, String)> {
-    let sock = TcpStream::connect(self.address.clone())?;
-    let mut sess = Session::new()?;
-    sess.set_tcp_stream(sock);
-    sess.handshake()?;
-    sess.userauth_agent(&self.user)?;
-
+    let sess = self.get_session()?;
     let mut channel = sess.channel_session()?;
     channel.exec(command)?;
 
@@ -41,6 +42,80 @@ impl Host {
     let exit_code = channel.exit_status()?;
 
     Ok((exit_code, output))
+  }
+
+  pub fn send_data(
+    &self,
+    remote_path: String,
+    file_mode: i32,
+    file_size: u64,
+    data: String,
+  ) -> Result<()> {
+    let sess = self.get_session()?;
+    let mut channel = sess.scp_send(
+      Path::new(&remote_path),
+      file_mode,
+      file_size,
+      None
+    )?;
+
+    channel.write(data.as_bytes())?;
+    channel.send_eof()?;
+    channel.wait_eof()?;
+    channel.close()?;
+    channel.wait_close()?;
+
+    Ok(())
+  }
+
+  pub fn send_file(
+    &self,
+    local_path: String,
+    remote_path: String,
+    file_mode: i32,
+    file_size: u64,
+  ) -> Result<()> {
+    let sess = self.get_session()?;
+    let mut channel = sess.scp_send(
+      Path::new(&remote_path),
+      file_mode,
+      file_size,
+      None
+    )?;
+
+    let file = File::open(&local_path)?;
+    let block_size = 4 * 1024 * 1024; // 4 megabytes
+    let mut reader = BufReader::with_capacity(block_size, file);
+
+    loop {
+      let buffer = reader.fill_buf()?;
+      let length = buffer.len();
+
+      if length > 0 {
+        channel.write(buffer)?;
+      }
+      else {
+        channel.send_eof()?;
+        channel.wait_eof()?;
+        channel.close()?;
+        channel.wait_close()?;
+        break;
+      }
+
+      reader.consume(length);
+    }
+
+    Ok(())
+  }
+
+  fn get_session(&self) -> Result<Session> {
+    let sock = TcpStream::connect(self.address.clone())?;
+    let mut sess = Session::new()?;
+    sess.set_tcp_stream(sock);
+    sess.handshake()?;
+    sess.userauth_agent(&self.user)?;
+
+    Ok(sess)
   }
 
   pub fn default_user() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,24 @@ fn main() -> Result<()> {
           .required(true)
         )
     )
+    .subcommand(
+      Command::new("upload")
+        .about("Upload a file to multiple hosts")
+        .arg(
+          arg!(template: -T --template "If set, the file is a template with the current host as context data")
+        )
+        .arg(
+          arg!(local_path: [LOCAL_PATH] "Path on local host to the file to be uploaded")
+          .required(true)
+        )
+        .arg(
+          arg!(remote_path: [REMOTE_PATH] "Path on remote host to upload the file")
+          .required(true)
+        )
+        .arg(
+          arg!(file_mode: [MODE] "UNIX file mode to set on the uploaded file (default: 0644)")
+        )
+    )
     .get_matches();
 
   cli::run(matches)


### PR DESCRIPTION
**This PR provides the following changes:**

 - [x] :sparkles: Add `send_data` and `send_file` functions to `Host`
 - [x] :heavy_plus_sign: Add `file-mode` dependency
 - [x] :sparkles: Add `upload` subcommand