### PR TITLE
:sparkles: Validate host ID and tags syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +349,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +488,7 @@ dependencies = [
  "file-mode",
  "is_executable",
  "rayon",
+ "regex",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ toml = "0.5"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+regex = "1.5"
 
 rayon = "1.5"
 

--- a/README.md
+++ b/README.md
@@ -99,16 +99,16 @@ in your scripts.
 software:
 
 ```rust
-use tricorder::core::{Inventory, Host};
+use tricorder::core::{Inventory, Host, HostId, HostTag};
 use tricorder::tasks::{TaskRunner, exec};
 use serde_json::json;
 
 let inventory = Inventory::new()
   .add_host(
-    Host::new("localhost".to_string(), "localhost:22".to_string())
+    Host::new(HostId::new("localhost").unwrap(), "localhost:22".to_string())
       .set_user("root".to_string())
-      .add_tag("local".to_string())
-      .set_var("msg", json!("hello"))
+      .add_tag(HostTag::new("local").unwrap())
+      .set_var("msg".to_string(), json!("hello"))
   );
 
 let task = exec::Task::new("echo \"{host.id} says {host.vars.msg}\"".to_string());

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
   FileNotFound(String),
   IsADirectory(String),
   IsAbsolute(String),
+  InvalidHostId(String),
+  InvalidHostTag(String),
 }
 
 impl Display for Error {

--- a/src/core/inventory.rs
+++ b/src/core/inventory.rs
@@ -1,4 +1,4 @@
-use crate::core::{Result, Error, Host};
+use crate::core::{Result, Error, Host, HostId, HostTag};
 use serde_derive::{Serialize, Deserialize};
 
 use is_executable::IsExecutable;
@@ -98,20 +98,20 @@ impl Inventory {
 
   /// Remove host from the inventory or do nothing if the host's ID was not
   /// found.
-  pub fn remove_host(&mut self, host_id: String) -> &mut Self {
+  pub fn remove_host(&mut self, host_id: HostId) -> &mut Self {
     self.hosts.retain(|host| host.id != host_id);
     self
   }
 
   /// Get `Some(host)` by its ID, or `None` if it does not exist.
-  pub fn get_host_by_id(&self, id: String) -> Option<Host> {
+  pub fn get_host_by_id(&self, id: HostId) -> Option<Host> {
     self.hosts.iter()
       .find(|host| host.id == id)
       .map(|host| host.clone())
   }
 
   /// Get a list of host matching at least on of the provided tags.
-  pub fn get_hosts_by_tags(&self, tags: Vec<String>) -> Vec<Host> {
+  pub fn get_hosts_by_tags(&self, tags: Vec<HostTag>) -> Vec<Host> {
     self.hosts
       .iter()
       .filter(|host| {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -32,16 +32,18 @@
 //! Or directly via the Rust API:
 //!
 //! ```rust
-//! use tricorder::core::{Inventory, Host};
+//! use tricorder::core::{Inventory, Host, HostId, HostTag};
 //! use serde_json::json;
 //!
 //! let inventory = Inventory::new()
 //!   .add_host(
-//!     Host::new("localhost", "localhost:22")
-//!       .set_user("root")
-//!       .add_tag("local")
-//!       .set_var("foo", json!("bar"))
-//!   );
+//!     Host::new(HostId::new("localhost").unwrap(), "localhost:22".to_string())
+//!       .set_user("root".to_string())
+//!       .add_tag(HostTag::new("local").unwrap())
+//!       .set_var("foo".to_string(), json!("bar"))
+//!       .to_owned()
+//!   )
+//!   .to_owned();
 //! ```
 
 mod result;
@@ -53,5 +55,5 @@ pub use self::{
   result::Result,
   error::Error,
   inventory::Inventory,
-  host::Host,
+  host::{Host, HostId, HostTag},
 };

--- a/src/tasks/download.rs
+++ b/src/tasks/download.rs
@@ -2,20 +2,22 @@
 //!
 //! Example usage:
 //!
-//! ```rust
-//! use tricorder::core::{Inventory, Host};
+//! ```no_run
+//! use tricorder::core::{Inventory, Host, HostId, HostTag};
 //! use tricorder::tasks::{TaskRunner, download};
 //! use serde_json::json;
 //!
 //! let inventory = Inventory::new()
 //!   .add_host(
-//!     Host::new("localhost".to_string(), "localhost:22".to_string())
+//!     Host::new(HostId::new("localhost").unwrap(), "localhost:22".to_string())
 //!       .set_user("root".to_string())
-//!       .add_tag("local".to_string())
-//!       .set_var("msg", json!("hello"))
-//!   );
+//!       .add_tag(HostTag::new("local").unwrap())
+//!       .set_var("msg".to_string(), json!("hello"))
+//!       .to_owned()
+//!   )
+//!   .to_owned();
 //!
-//! let task = download::Task::new_template(
+//! let task = download::Task::new(
 //!   "/path/to/remote/file.ext".to_string(),
 //!   "file.ext".to_string(),
 //! );
@@ -81,7 +83,7 @@ impl TaskTrait<String> for Task {
     }
 
     let cwd = env::current_dir()?;
-    let fullpath = cwd.join(host.id).join(local_path);
+    let fullpath = cwd.join(host.id.to_string()).join(local_path);
     let fulldir = fullpath.parent().unwrap();
     fs::create_dir_all(fulldir)?;
 

--- a/src/tasks/exec.rs
+++ b/src/tasks/exec.rs
@@ -2,18 +2,20 @@
 //!
 //! Example usage:
 //!
-//! ```rust
-//! use tricorder::core::{Inventory, Host};
+//! ```no_run
+//! use tricorder::core::{Inventory, Host, HostId, HostTag};
 //! use tricorder::tasks::{TaskRunner, exec};
 //! use serde_json::json;
 //!
 //! let inventory = Inventory::new()
 //!   .add_host(
-//!     Host::new("localhost".to_string(), "localhost:22".to_string())
+//!     Host::new(HostId::new("localhost").unwrap(), "localhost:22".to_string())
 //!       .set_user("root".to_string())
-//!       .add_tag("local".to_string())
-//!       .set_var("msg", json!("hello"))
-//!   );
+//!       .add_tag(HostTag::new("local").unwrap())
+//!       .set_var("msg".to_string(), json!("hello"))
+//!       .to_owned()
+//!   )
+//!   .to_owned();
 //!
 //! let task = exec::Task::new("echo \"{host.id} says {host.vars.msg}\"".to_string());
 //! let result = inventory.hosts.run_task_seq(&task).unwrap();

--- a/src/tasks/info.rs
+++ b/src/tasks/info.rs
@@ -2,18 +2,20 @@
 //!
 //! Example usage:
 //!
-//! ```rust
-//! use tricorder::core::{Inventory, Host};
+//! ```no_run
+//! use tricorder::core::{Inventory, Host, HostId, HostTag};
 //! use tricorder::tasks::{TaskRunner, info};
 //! use serde_json::json;
 //!
 //! let inventory = Inventory::new()
 //!   .add_host(
-//!     Host::new("localhost".to_string(), "localhost:22".to_string())
+//!     Host::new(HostId::new("localhost").unwrap(), "localhost:22".to_string())
 //!       .set_user("root".to_string())
-//!       .add_tag("local".to_string())
-//!       .set_var("msg", json!("hello"))
-//!   );
+//!       .add_tag(HostTag::new("local").unwrap())
+//!       .set_var("msg".to_string(), json!("hello"))
+//!       .to_owned()
+//!   )
+//!   .to_owned();
 //!
 //! let task = info::Task::new();
 //! let result = inventory.hosts.run_task_seq(&task).unwrap();

--- a/src/tasks/upload.rs
+++ b/src/tasks/upload.rs
@@ -2,18 +2,20 @@
 //!
 //! Example usage:
 //!
-//! ```rust
-//! use tricorder::core::{Inventory, Host};
+//! ```no_run
+//! use tricorder::core::{Inventory, Host, HostId, HostTag};
 //! use tricorder::tasks::{TaskRunner, upload};
 //! use serde_json::json;
 //!
 //! let inventory = Inventory::new()
 //!   .add_host(
-//!     Host::new("localhost".to_string(), "localhost:22".to_string())
+//!     Host::new(HostId::new("localhost").unwrap(), "localhost:22".to_string())
 //!       .set_user("root".to_string())
-//!       .add_tag("local".to_string())
-//!       .set_var("msg", json!("hello"))
-//!   );
+//!       .add_tag(HostTag::new("local").unwrap())
+//!       .set_var("msg".to_string(), json!("hello"))
+//!       .to_owned()
+//!   )
+//!   .to_owned();
 //!
 //! let task = upload::Task::new_template(
 //!   "/path/to/local/file.ext".to_string(),


### PR DESCRIPTION
**This PR provides the following changes:**

 - [x] :heavy_plus_sign: Add `regex` crate
 - [x] :sparkles: Add `HostId` and `HostTag` types to validate the syntax with a regex
 - [x] :recycle: Update `Inventory` API and CLI
 - [x] :memo: Update documentation

The new syntax is:

 - Host ID : `^[a-zA-Z0-9_][a-zA-Z0-9_\-]*$`
 - Host Tag : `^[^!\&\|\t\n\r\f ]+$`